### PR TITLE
Fix the bcprov-jdk15on version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.6</version>
+			<version>1.68</version>
 		</dependency>
 		<dependency>
 			<groupId>com.nimbusds</groupId>


### PR DESCRIPTION
Version `1.6` is not available in maven repository. Bumping this to make the code compile.
https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on